### PR TITLE
redis + report display example

### DIFF
--- a/redis_instance.py
+++ b/redis_instance.py
@@ -1,0 +1,3 @@
+import redis
+import os
+r = redis.StrictRedis.from_url(os.environ['REDIS_URL'])

--- a/tasks.py
+++ b/tasks.py
@@ -1,15 +1,15 @@
 import datetime
 import time
 import os
-
 from celery import Celery
-
+import redis
+from redis_instance import r
 
 celery_app = Celery('hello', broker=os.environ['REDIS_URL'])
 
 
 @celery_app.task
-def hello():
-    time.sleep(10)
-    with open ('hellos.txt', 'a') as hellofile:
-        hellofile.write('Hello {}\n'.format(datetime.datetime.now()))
+def hello(task_id):
+    r.hset(task_id, 'status', 'running')
+    time.sleep(120)
+    r.hset(task_id, 'status', 'complete')


### PR DESCRIPTION
This PR is meant to be closed (this would either remain a branch of `dash-redis-demo` or would become its own repo.) This PR is just meant to open some discussion.

@chriddyp let me know what you think of this toy example.

The major deviation from what you posted in slack was not using the `reports` key. I was a bit confused about how were you actually using it. From my reading of it, the `time.time()` ids you're using are meaningless, and you're in essence using `reports` as just a list of report names (similar to looping through `some_dict.iteritems()` in python.)

If that's the case, I think it makes sense for me to redesign this branch so we keep a separate list of "reports". It's more robust to have a list of reports to iterate through than to do the key parsing I'm doing.

If it's not the case, let me know what you were using those time keys for. Ideally, in this case, all I want is to be able to retrieve an array of report IDs. It _seems_ like redis only stores hashes so iterating through those hashes while ignoring the keys is the best way to iterate through a list, but let me know if I'm wrong.

I think this is a good example of how a more general use of redis for long tasks in Dash. Lanre is simply generating CSVs that will be hosted, so it's not _directly_ comparable to the invesco example. This is a good framework that could lead to both a report-based Invesco-like example, or any other general long process (I'm thinking of examples where dash allows users to input parameters to a computationally costly model)